### PR TITLE
v0.11.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,11 @@
 # Change log
 All notable changes to this project will be documented in this file.
 
+## [0.11.1] -- 2024-01-17
+
+### Fixed
+ - changed PEPATACr.R to use lapply instead of sapply when converting yaml to data.table object
+
 ## [0.11.0] -- 2023-12-22
 
 ### Fixed

--- a/pipelines/pepatac.py
+++ b/pipelines/pepatac.py
@@ -5,7 +5,7 @@ PEPATAC - ATACseq pipeline
 
 __author__ = ["Jin Xu", "Nathan Sheffield", "Jason Smith"]
 __email__ = "jasonsmith@virginia.edu"
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 
 
 from argparse import ArgumentParser

--- a/pipelines/pepatac_collator.py
+++ b/pipelines/pepatac_collator.py
@@ -5,7 +5,7 @@ PEPATAC Collator - ATAC-seq project-level pipeline
 
 __author__ = ["Jason Smith", "Michal Stolarczyk"]
 __email__ = "jasonsmith@virginia.edu"
-__version__ = "0.0.6"
+__version__ = "0.0.7"
 
 from argparse import ArgumentParser
 import os


### PR DESCRIPTION
## [0.11.1] -- 2024-01-17

### Fixed
 - changed PEPATACr.R to use lapply instead of sapply when converting yaml to data.table object
#264