### PR TITLE
Attempt to fix datatable issue in R

### DIFF
--- a/PEPATACr/R/PEPATACr.R
+++ b/PEPATACr/R/PEPATACr.R
@@ -2446,7 +2446,8 @@ yamlToDT <- function(sample_name, yaml_file) {
                      "cFRiF",
                      "FRiF",
                      "FastQC report r1",
-                     "FastQC report r2")
+                     "FastQC report r2",
+                     "meta")
     cols_present <- character()
     for (column_name in remove_cols) {
         if (any(grepl(column_name, names(sample_DT)))) {
@@ -2485,9 +2486,15 @@ summarizer <- function(project, output_dir) {
     # Produce output directory (if needed)
     dir.create(summary_dir, showWarnings = FALSE)
 
-    # convert yaml to data.table object
-    stats <- data.table::rbindlist(lapply(project_samples, FUN=yamlToDT,
-                                          yaml_file=summary_file), fill=TRUE)
+    # # convert yaml to data.table object
+    # stats <- data.table::rbindlist(lapply(project_samples, FUN=yamlToDT,
+    #                                       yaml_file=summary_file), fill=TRUE)
+
+    # Convert YAML to data.table objects
+    sample_dts <- lapply(project_samples, FUN=yamlToDT, yaml_file=summary_file)
+
+    # Combine data.tables
+    stats <- data.table::rbindlist(sample_dts, idcol = "sample_name", fill = TRUE)
 
     # Set absent values in table to zero
     stats[is.na(stats)]   <- 0


### PR DESCRIPTION
When using datable.table 1.16.0, PEPATACr.R was giving me an error:
```
Error in forderv(x, by = by, sort = FALSE, retGrp = TRUE) : 
  Column 1 passed to [f]order is type 'list', not yet supported.
Calls: <Anonymous> ... lapply -> FUN -> unique -> unique.data.table -> forderv
Execution halted
```

I refactored the creation of the stats data table. The project-level pipeline seems to work but now it gives me a warning:

```
Creating summary plots...
Warning messages:
1: In as.data.table.list(yaml_file$PEPATAC$sample[[sample_name]]) :
  Item 1 has 3 rows but longest item has 4; recycled with remainder.
2: In as.data.table.list(yaml_file$PEPATAC$sample[[sample_name]]) :
  Item 1 has 3 rows but longest item has 4; recycled with remainder
```
