### PR TITLE
0.12.2 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,9 @@
 # Change log
 All notable changes to this project will be documented in this file.
 
+## [0.12.2] -- 2025-02-13
+- Bump rust-gtars to v0.2.1: https://anaconda.org/bioconda/rust-gtars
+
 ## [0.12.1] -- 2025-02-10
 - Bump pipestat version to fix this issue: https://github.com/pepkit/pipestat/issues/215
 

--- a/pipelines/pepatac.py
+++ b/pipelines/pepatac.py
@@ -5,7 +5,7 @@ PEPATAC - ATACseq pipeline
 
 __author__ = ["Jin Xu", "Nathan Sheffield", "Jason Smith"]
 __email__ = "jasonsmith@virginia.edu"
-__version__ = "0.12.1"
+__version__ = "0.12.2"
 
 
 from argparse import ArgumentParser

--- a/requirements-conda.yml
+++ b/requirements-conda.yml
@@ -453,7 +453,7 @@ dependencies:
   - rfc3339-validator=0.1.4=py310h06a4308_0
   - rfc3986-validator=0.1.1=py310h06a4308_0
   - rpds-py=0.10.6=py310h4aa5aa6_1
-  - rust-gtars=0.2.0=h4349ce8_0
+  - rust-gtars=0.2.1=h4349ce8_0
   - samblaster=0.1.26=h9948957_6
   - sed=4.8=h7b6447c_0
   - send2trash=1.8.2=py310h06a4308_0


### PR DESCRIPTION
## [0.12.2] -- 2025-02-13
- Bump rust-gtars to v0.2.1: https://anaconda.org/bioconda/rust-gtars