### PR TITLE
typo and style for pip install in run-bulker.md

### DIFF
--- a/docs/run-bulker.md
+++ b/docs/run-bulker.md
@@ -18,7 +18,10 @@ git clone https://github.com/databio/pepatac.git
 ```
 
 ### 2. Install python package requirements
-`pip install -r /pepatac/requirements.txt`
+
+```console
+pip install -r pepatac/requirements.txt
+```
 
 ### 3. Get genome assets
 


### PR DESCRIPTION
just trying to install pepatac via bulker, and suggest removing the leading `/` for the install command.